### PR TITLE
Remove duplicate elixir-ts-mode--reserved-keywords

### DIFF
--- a/elixir-ts-mode.el
+++ b/elixir-ts-mode.el
@@ -183,10 +183,6 @@
   '("when" "and" "or" "not" "in"
     "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
 
-(defconst elixir-ts-mode--reserved-keywords
-  '("when" "and" "or" "not" "in"
-    "not in" "fn" "do" "end" "catch" "rescue" "after" "else"))
-
 (defconst elixir-ts-mode--reserved-keywords-re
   (concat "^" (regexp-opt elixir-ts-mode--reserved-keywords) "$"))
 


### PR DESCRIPTION
I found it's already defined. This changes try removing the duplicate one.